### PR TITLE
feature: Admin now can see all appointment details

### DIFF
--- a/app/admin/admin_routes.py
+++ b/app/admin/admin_routes.py
@@ -1,8 +1,10 @@
 from flask import Blueprint, request ,jsonify
+from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import SQLAlchemyError
 from app.common.utils.decorator import admin_required
 from app.admin.services.admin_service import promote_user_service, onboard_doctor_service, assign_doctor_service
 from app.admin.services.department_service import create_department_service, list_departments_service
+from app.admin.services.appointment_service import get_all_appointments_service
 from app.admin.schemas.department_schema import DepartmentSchema
 from app.admin.schemas.assign_doctor_schema import AssignDoctorSchema
 from app.admin.schemas.onboard_doctor_schema import OnboardDoctorSchema
@@ -72,6 +74,16 @@ def assign_doctor():
         return jsonify(e.messages), 400
     except SQLAlchemyError:
         return jsonify({'message': 'Something went wrong'}), 500
+
+@admin_bp.route("/appointments", methods=["GET"])
+@jwt_required()
+@admin_required
+def get_all_appointments():
+    try:
+        appointments = get_all_appointments_service()
+        return jsonify({"appointments": appointments}), 200
+    except Exception as e:
+        return jsonify({"message": f"Something went wrong: {e}"}), 500
 
 
 

--- a/app/admin/repositories/appointment_repository.py
+++ b/app/admin/repositories/appointment_repository.py
@@ -1,0 +1,8 @@
+from app.member.book_appointment.models.appointment import Appointment
+
+def fetch_all_appointments():
+    """
+    Fetch all appointments from the database.
+    """
+    return Appointment.query.order_by(Appointment.id.desc()).all()
+

--- a/app/admin/services/appointment_service.py
+++ b/app/admin/services/appointment_service.py
@@ -1,0 +1,20 @@
+from app.admin.repositories.appointment_repository import fetch_all_appointments
+
+def get_all_appointments_service():
+    """
+    Fetch all appointments and format the data for admin.
+    """
+    appointments = fetch_all_appointments()
+    result = []
+
+    for a in appointments:
+        result.append({
+            "id": a.id,
+            "doctor_id": a.doctor_id,
+            "member_id": a.member_id,
+            "availability_id": a.availability_id,
+            "status": a.status,
+            "created_at": a.created_at.isoformat()
+        })
+
+    return result


### PR DESCRIPTION
This PR introduces a new endpoint that allows admin users to view all appointments in the system. The implementation includes:
**Admin-only route**:` /admin/appointments (GET request)`
**Service layer** to fetch all appointment data
**Repository layer** to query the database
**RBAC** checks to ensure only admins can access the data
Error handling for database failures

### Changes include:

- admin_routes.py – added route for fetching all appointments
- admin_service.py – added service function to get all appointments
- appointment_reposiotry.py – added repository function to fetch appointments from the database
- Postman test cases prepared for:
        -       Success (list of all appointments)
        -       Unauthorized access (non-admin users)

### Acceptance Criteria:

- Admin can view all appointments with all relevant fields (appointment ID, doctor, member, availability, status, created_at)
- Non-admin users cannot access the endpoint
- Proper success and error responses are returned

### Done Criteria:

- Endpoint tested with Postman
- Code follows existing service and repository structure
- Proper error messages and status codes implemented